### PR TITLE
add github.com/rh-ibm-synergy to GOPRIVATE

### DIFF
--- a/prow/cluster/jobs/rh-ibm-synergy/multicloud-operators-cluster-controller/rh-ibm-synergy.multicloud-operators-cluster-controller.master.yaml
+++ b/prow/cluster/jobs/rh-ibm-synergy/multicloud-operators-cluster-controller/rh-ibm-synergy.multicloud-operators-cluster-controller.master.yaml
@@ -1,3 +1,8 @@
+presets:
+- env:
+  - name: GOPRIVATE
+    value: github.com/rh-ibm-synergy
+
 presubmits:
   rh-ibm-synergy/multicloud-operators-cluster-controller:
   - name: build_multicloud-operators-cluster-controller


### PR DESCRIPTION
**What this PR does / why we need it**:

add `export GOPRIVATE=github.com/rh-ibm-synergy` to presets for  multicloud-operator-cluster-controllers jobs to fix 
```
reading https://proxy.golang.org/github.com/rh-ibm-synergy/multicloud-operators-foundation/@v/v0.0.0-20191216172235-60e7a00eac53.mod: 410 Gone
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/rh-ibm-synergy/multicloud-operators-cluster-controller/issues/25

**Specify your PR reviewers**:
<!-- Add or remove reviewers as your request -->
/cc @gyliu513 @morvencao @clyang82

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

NO 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
add `export GOPRIVATE=github.com/rh-ibm-synergy` to presets for  multicloud-operator-cluster-controllers jobs
```
