### PR TITLE
update multicloud-operators-cluster-controller prow job

### DIFF
--- a/prow/cluster/jobs/rh-ibm-synergy/multicloud-operators-cluster-controller/rh-ibm-synergy.multicloud-operators-cluster-controller.master.yaml
+++ b/prow/cluster/jobs/rh-ibm-synergy/multicloud-operators-cluster-controller/rh-ibm-synergy.multicloud-operators-cluster-controller.master.yaml
@@ -1,7 +1,7 @@
 presets:
 - env:
   - name: GOPRIVATE
-    value: github.com/rh-ibm-synergy
+    value: github.ibm.com,github.com/rh-ibm-synergy
 
 presubmits:
   rh-ibm-synergy/multicloud-operators-cluster-controller:


### PR DESCRIPTION

**What this PR does / why we need it**:
add github.ibm.com to GOPRIVATE for multicloud-operators-cluster-controller prow job

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Specify your PR reviewers**:
<!-- Add or remove reviewers as your request -->
/cc @gyliu513 @morvencao @clyang82

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
add github.ibm.com to GOPRIVATE for multicloud-operators-cluster-controller prow job
```
