### PR TITLE
add ssh secret volumn and mount to preset

### DIFF
--- a/prow/cluster/jobs/rh-ibm-synergy/multicloud-operators-cluster-controller/rh-ibm-synergy.multicloud-operators-cluster-controller.master.yaml
+++ b/prow/cluster/jobs/rh-ibm-synergy/multicloud-operators-cluster-controller/rh-ibm-synergy.multicloud-operators-cluster-controller.master.yaml
@@ -7,9 +7,9 @@ presets:
     secret:
       secretName: ssh-secret
 - volumeMounts:
-   - mountPath: /home/ssh
-      name: ssh-keys-ssh-secret
-      readOnly: true
+  - mountPath: /home/ssh
+    name: ssh-keys-ssh-secret
+    readOnly: true
 
 presubmits:
   rh-ibm-synergy/multicloud-operators-cluster-controller:

--- a/prow/cluster/jobs/rh-ibm-synergy/multicloud-operators-cluster-controller/rh-ibm-synergy.multicloud-operators-cluster-controller.master.yaml
+++ b/prow/cluster/jobs/rh-ibm-synergy/multicloud-operators-cluster-controller/rh-ibm-synergy.multicloud-operators-cluster-controller.master.yaml
@@ -7,7 +7,7 @@ presets:
     secret:
       secretName: ssh-secret
 - volumeMounts:
-   - mountPath: /home/ssh/ssh-secret
+   - mountPath: /home/ssh
       name: ssh-keys-ssh-secret
       readOnly: true
 

--- a/prow/cluster/jobs/rh-ibm-synergy/multicloud-operators-cluster-controller/rh-ibm-synergy.multicloud-operators-cluster-controller.master.yaml
+++ b/prow/cluster/jobs/rh-ibm-synergy/multicloud-operators-cluster-controller/rh-ibm-synergy.multicloud-operators-cluster-controller.master.yaml
@@ -2,6 +2,14 @@ presets:
 - env:
   - name: GOPRIVATE
     value: github.ibm.com,github.com/rh-ibm-synergy
+- volumes:
+  - name: ssh-keys-ssh-secret
+    secret:
+      secretName: ssh-secret
+- volumeMounts:
+   - mountPath: /home/ssh/ssh-secret
+      name: ssh-keys-ssh-secret
+      readOnly: true
 
 presubmits:
   rh-ibm-synergy/multicloud-operators-cluster-controller:


### PR DESCRIPTION
**What this PR does / why we need it**:
update cluster-operators-cluster-controller preset to add ssh secret volumn and mount for cloning private github projects

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/rh-ibm-synergy/multicloud-operators-cluster-controller/issues/26

**Specify your PR reviewers**:
<!-- Add or remove reviewers as your request -->
/cc @gyliu513 @morvencao @clyang82

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
update cluster-operators-cluster-controller preset to add ssh secret volumn and mount for cloning private github projects
```
