### PR TITLE
onboard ibm-cloudctl-operator.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -24,6 +24,7 @@ tide:
     IBM/test-infra: squash
     IBM/common-service-operator: squash
     IBM/ibm-catalog-operator: squash
+    IBM/ibm-cloudctl-operator: squash
     IBM/ibm-metering-operator: squash
     IBM/multicloud-operators-subscription-release: squash
     IBM/multicloud-operators-policy-controller: squash
@@ -46,6 +47,7 @@ tide:
     - IBM/test-infra
     - IBM/common-service-operator
     - IBM/ibm-catalog-operator
+    - IBM/ibm-cloudctl-operator
     - IBM/ibm-metering-operator
     - IBM/multicloud-operators-subscription-release
     - IBM/multicloud-operators-policy-controller


### PR DESCRIPTION
**What this PR does / why we need it**:

followup PR for https://github.com/IBM/test-infra/pull/72
- add tide configuration for ibm-cloudctl-operator

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Specify your PR reviewers**:
<!-- Add or remove reviewers as your request -->
/cc @gyliu513 @morvencao @clyang82

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
