### PR TITLE
fix incorrect secret name for coverage token.

### DIFF
--- a/prow/cluster/jobs/IBM/common-service-operator/IBM.common-service-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/common-service-operator/IBM.common-service-operator.master.yaml
@@ -98,7 +98,7 @@ postsubmits:
         - name: CODECOV_TOKEN
           valueFrom:
             secretKeyRef:
-              name: ibm-common-service-operator-codecov-token
+              name: common-service-operator-codecov-token
               key: codecov-token
         securityContext:
           privileged: true


### PR DESCRIPTION
**What this PR does / why we need it**:

The coverage token secret name for `https://github.com/IBM/common-service-operator` should be `common-service-operator-codecov-token` instead of `ibm-common-service-operator-codecov-token`


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Specify your PR reviewers**:
<!-- Add or remove reviewers as your request -->
/cc @gyliu513 @morvencao @clyang82

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
