### PR TITLE
update build tool version for License Service

### DIFF
--- a/prow/cluster/jobs/IBM/ibm-licensing-operator/IBM.ibm-licensing-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-licensing-operator/IBM.ibm-licensing-operator.master.yaml
@@ -13,7 +13,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20200319-b5bfe54
+        image: quay.io/multicloudlab/check-tool:v20200806-cf0548d
         name: ""
         securityContext:
           privileged: true
@@ -32,7 +32,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
+        image: quay.io/multicloudlab/build-tool:v20200806-cf0548d
         name: ""
         securityContext:
           privileged: true
@@ -51,7 +51,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
+        image: quay.io/multicloudlab/build-tool:v20200806-cf0548d
         name: ""
         securityContext:
           privileged: true
@@ -70,7 +70,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
+        image: quay.io/multicloudlab/build-tool:v20200806-cf0548d
         name: ""
         securityContext:
           privileged: true
@@ -89,7 +89,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
+        image: quay.io/multicloudlab/build-tool:v20200806-cf0548d
         name: ""
         securityContext:
           privileged: true
@@ -108,7 +108,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
+        image: quay.io/multicloudlab/build-tool:v20200806-cf0548d
         name: ""
         securityContext:
           privileged: true
@@ -127,7 +127,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
+        image: quay.io/multicloudlab/build-tool:v20200806-cf0548d
         name: ""
         securityContext:
           privileged: true
@@ -144,7 +144,7 @@ postsubmits:
       - command:
         - make
         - coverage
-        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
+        image: quay.io/multicloudlab/build-tool:v20200806-cf0548d
         name: ""
         env:
         - name: CODECOV_TOKEN
@@ -166,7 +166,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
+        image: quay.io/multicloudlab/build-tool:v20200806-cf0548d
         name: ""
         securityContext:
           privileged: true
@@ -182,7 +182,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
+        image: quay.io/multicloudlab/build-tool:v20200806-cf0548d
         name: ""
         securityContext:
           privileged: true
@@ -198,7 +198,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
+        image: quay.io/multicloudlab/build-tool:v20200806-cf0548d
         name: ""
         securityContext:
           privileged: true        
@@ -216,7 +216,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
+        image: quay.io/multicloudlab/build-tool:v20200806-cf0548d
         name: ""
         securityContext:
           privileged: true
@@ -234,7 +234,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
+        image: quay.io/multicloudlab/build-tool:v20200806-cf0548d
         name: ""
         securityContext:
           privileged: true
@@ -252,7 +252,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
+        image: quay.io/multicloudlab/build-tool:v20200806-cf0548d
         name: ""
         securityContext:
           privileged: true         
@@ -270,7 +270,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
+        image: quay.io/multicloudlab/build-tool:v20200806-cf0548d
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-licensing-operator/IBM.ibm-licensing-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-licensing-operator/IBM.ibm-licensing-operator.master.yaml
@@ -32,7 +32,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20200320-5e25536
+        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
         name: ""
         securityContext:
           privileged: true
@@ -51,7 +51,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20200320-5e25536
+        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
         name: ""
         securityContext:
           privileged: true
@@ -70,7 +70,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20200320-5e25536
+        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
         name: ""
         securityContext:
           privileged: true
@@ -89,7 +89,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20200320-5e25536
+        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
         name: ""
         securityContext:
           privileged: true
@@ -108,7 +108,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20200320-5e25536
+        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
         name: ""
         securityContext:
           privileged: true
@@ -127,7 +127,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20200320-5e25536
+        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
         name: ""
         securityContext:
           privileged: true
@@ -144,7 +144,7 @@ postsubmits:
       - command:
         - make
         - coverage
-        image: quay.io/multicloudlab/build-tool:v20200320-5e25536
+        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
         name: ""
         env:
         - name: CODECOV_TOKEN
@@ -166,7 +166,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20200320-5e25536
+        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
         name: ""
         securityContext:
           privileged: true
@@ -182,7 +182,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20200320-5e25536
+        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
         name: ""
         securityContext:
           privileged: true
@@ -198,7 +198,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20200320-5e25536
+        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
         name: ""
         securityContext:
           privileged: true        
@@ -216,7 +216,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20200320-5e25536
+        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
         name: ""
         securityContext:
           privileged: true
@@ -234,7 +234,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20200320-5e25536
+        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
         name: ""
         securityContext:
           privileged: true
@@ -252,7 +252,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20200320-5e25536
+        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
         name: ""
         securityContext:
           privileged: true         
@@ -270,7 +270,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20200320-5e25536
+        image: quay.io/multicloudlab/build-tool:v20200804-eb09a54
         name: ""
         securityContext:
           privileged: true


### PR DESCRIPTION
**What this PR does / why we need it**:

previous build tool had go version 1.13.8 with vulnerabilities, new one has 1.14.6 which is ok

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/40090

**Specify your PR reviewers**:
<!-- Add or remove reviewers as your request -->
/cc @gyliu513 @morvencao @clyang82

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
This PR change only image versions for build-tool

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
new prow build needs to be build in case to have newer golang version for operator
```
