### PR TITLE
update build tool version for ibm-auditlogging-operator

### DIFF
--- a/prow/cluster/jobs/IBM/ibm-auditlogging-operator/IBM.ibm-auditlogging-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-auditlogging-operator/IBM.ibm-auditlogging-operator.master.yaml
@@ -12,7 +12,7 @@ presubmits:
       - command:
         - make
         - build
-        image: quay.io/multicloudlab/build-tools:v20191217-d33a10d
+        image: quay.io/multicloudlab/build-tools:v20200806-cf0548d
         name: ""
         securityContext:
           privileged: true
@@ -29,7 +29,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/build-tools:v20191217-d33a10d
+        image: quay.io/multicloudlab/build-tools:v20200806-cf0548d
         name: ""
         securityContext:
           privileged: true
@@ -46,7 +46,7 @@ presubmits:
       - command:
         - make
         - test
-        image: quay.io/multicloudlab/build-tools:v20191217-d33a10d
+        image: quay.io/multicloudlab/build-tools:v20200806-cf0548d
         name: ""
         securityContext:
           privileged: true
@@ -64,7 +64,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/build-tools:v20191217-d33a10d
+        image: quay.io/multicloudlab/build-tools:v20200806-cf0548d
         name: ""
         securityContext:
           privileged: true
@@ -78,7 +78,7 @@ postsubmits:
       - command:
         - make
         - test
-        image: quay.io/multicloudlab/build-tools:v20191217-d33a10d
+        image: quay.io/multicloudlab/build-tools:v20200806-cf0548d
         name: ""
         securityContext:
           privileged: true
@@ -92,7 +92,7 @@ postsubmits:
       - command:
         - make
         - coverage
-        image: quay.io/multicloudlab/build-tools:v20191217-d33a10d
+        image: quay.io/multicloudlab/build-tools:v20200806-cf0548d
         name: ""
         env:
         - name: CODECOV_TOKEN
@@ -112,7 +112,7 @@ postsubmits:
       - command:
         - make
         - build
-        image: quay.io/multicloudlab/build-tools:v20191217-d33a10d
+        image: quay.io/multicloudlab/build-tools:v20200806-cf0548d
         name: ""
         securityContext:
           privileged: true
@@ -129,7 +129,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/multicloudlab-builder:v20191217-d33a10d
+        image: quay.io/multicloudlab/multicloudlab-builder:v20200806-cf0548d
         name: ""
         securityContext:
           privileged: true


### PR DESCRIPTION
**What this PR does / why we need it**:

previous build tool had go version 1.13.8 with vulnerabilities, new one has 1.14.6 which is ok

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Specify your PR reviewers**:
<!-- Add or remove reviewers as your request -->
/cc @gyliu513 @morvencao @clyang82

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
new prow build needs to be build in case to have newer golang version for operator
```
