### PR TITLE
remove build jobs for secretshare

### DIFF
--- a/prow/cluster/jobs/IBM/ibm-secretshare-operator/IBM.ibm-secretshare-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-secretshare-operator/IBM.ibm-secretshare-operator.master.yaml
@@ -155,54 +155,6 @@ postsubmits:
               key: codecov-token
         securityContext:
           privileged: true
-  - name: build-ibm-secretshare-operator-amd64-postsubmit
-    cluster: default
-    branches:
-    - ^master$
-    decorate: true
-    path_alias: github.com/IBM/ibm-secretshare-operator
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - make
-        - build
-        image: quay.io/multicloudlab/build-tool:v20200817-b1f2b4c05
-        name: ""
-        securityContext:
-          privileged: true
-  - name: build-ibm-secretshare-operator-ppc64le-postsubmit
-    cluster: ppc64le
-    branches:
-    - ^master$
-    decorate: true
-    path_alias: github.com/IBM/ibm-secretshare-operator
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - make
-        - build
-        image: quay.io/multicloudlab/build-tool:v20200817-b1f2b4c05
-        name: ""
-        securityContext:
-          privileged: true
-  - name: build-ibm-secretshare-operator-s390x-postsubmit
-    cluster: s390x
-    branches:
-    - ^master$
-    decorate: true
-    path_alias: github.com/IBM/ibm-secretshare-operator
-    spec:
-      containers:
-      - command:
-        - entrypoint
-        - make
-        - build
-        image: quay.io/multicloudlab/build-tool:v20200817-b1f2b4c05
-        name: ""
-        securityContext:
-          privileged: true
   - name: image-ibm-secretshare-operator-amd64-postsubmit
     cluster: default
     branches:


### PR DESCRIPTION
**What this PR does / why we need it**:

Since the ibm secretshare operator builds the go binary during the image build, the build jobs in the prow should be removed.

/assign @morvencao 

@morvencao Just want to confirm, Is there the only place I need to update to disable these jobs? How long will it take effect?

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Specify your PR reviewers**:
<!-- Add or remove reviewers as your request -->
/cc @gyliu513 @morvencao

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
