### PR TITLE
using build-tool as the code coverage job image

### DIFF
--- a/common/Makefile.common.mk
+++ b/common/Makefile.common.mk
@@ -74,6 +74,11 @@ format-go:
 	@${FINDFILES} -name '*.go' \( ! \( -name '*.gen.go' -o -name '*.pb.go' \) \) -print0 | ${XARGS} goimports -w -local "github.com/IBM"
 
 format-python:
+	tt3=$(shell which 2to3)
+ifeq (${tt3},)
+	@apt update
+	@apt install -y 2to3
+endif
 	@${FINDFILES} -name '*.py' -print0 | ${XARGS} autopep8 --max-line-length 160 --aggressive --aggressive -i
 
 format-protos:

--- a/prow/cluster/jobs/IBM/operand-deployment-lifecycle-manager/IBM.operand-deployment-lifecycle-manager.master.yaml
+++ b/prow/cluster/jobs/IBM/operand-deployment-lifecycle-manager/IBM.operand-deployment-lifecycle-manager.master.yaml
@@ -48,9 +48,10 @@ postsubmits:
     spec:
       containers:
       - command:
+        - entrypoint
         - make
         - coverage
-        image: quay.io/multicloudlab/check-tool:v20200817-b1f2b4c05
+        image: quay.io/multicloudlab/build-tool:v20200817-b1f2b4c05
         name: ""
         env:
         - name: CODECOV_TOKEN


### PR DESCRIPTION
**What this PR does / why we need it**:

Since ODLM unit test needs kubebuilder and kubebuilder is included in the image`build-tool`, I update the ODLM code coverage job to use `quay.io/multicloudlab/build-tool:v20200817-b1f2b4c05` as the job image.

@morvencao Please correct me if my update is wrong.

/cc @chenzhiwei @DanielXLee
/assign @morvencao 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Specify your PR reviewers**:
<!-- Add or remove reviewers as your request -->
/cc @gyliu513 @morvencao

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
