### PR TITLE
added new branches for ibm-platform-api-operator builds

### DIFF
--- a/prow/cluster/jobs/IBM/ibm-platform-api-operator/IBM.ibm-platform-api-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-platform-api-operator/IBM.ibm-platform-api-operator.master.yaml
@@ -3,6 +3,8 @@ presubmits:
   - name: build_ibm-platform-api-operator
     branches:
     - ^master$
+    - ^release-cd$
+    - ^release-efix$
     labels:
       preset-service-account: "true"
     decorate: true
@@ -23,6 +25,8 @@ presubmits:
   - name: check_ibm-platform-api-operator
     branches:
     - ^master$
+    - ^release-cd$
+    - ^release-efix$
     decorate: true
     always_run: true
     path_alias: github.com/IBM/ibm-platform-api-operator
@@ -40,6 +44,8 @@ presubmits:
   - name: test_ibm-platform-api-operator
     branches:
     - ^master$
+    - ^release-cd$
+    - ^release-efix$
     decorate: true
     always_run: true
     path_alias: github.com/IBM/ibm-platform-api-operator
@@ -61,6 +67,8 @@ postsubmits:
   - name: check_ibm-platform-api-operator_postsubmit
     branches:
     - ^master$
+    - ^release-cd$
+    - ^release-efix$
     decorate: true
     path_alias: github.com/IBM/ibm-platform-api-operator
     spec:
@@ -75,6 +83,8 @@ postsubmits:
   - name: test_ibm-platform-api-operator_postsubmit
     branches:
     - ^master$
+    - ^release-cd$
+    - ^release-efix$
     decorate: true
     path_alias: github.com/IBM/ibm-platform-api-operator
     spec:
@@ -90,6 +100,8 @@ postsubmits:
   - name: build_ibm-platform-api-operator_postsubmit
     branches:
     - ^master$
+    - ^release-cd$
+    - ^release-efix$
     labels:
       preset-service-account: "true"
     decorate: true
@@ -107,6 +119,8 @@ postsubmits:
   - name: images_ibm-platform-api-operator_postsubmit
     branches:
     - ^master$
+    - ^release-cd$
+    - ^release-efix$
     decorate: true
     path_alias: github.com/IBM/ibm-platform-api-operator
     labels:

--- a/prow/cluster/jobs/IBM/ibm-platform-api-operator/IBM.ibm-platform-api-operator.release-eus.yaml
+++ b/prow/cluster/jobs/IBM/ibm-platform-api-operator/IBM.ibm-platform-api-operator.release-eus.yaml
@@ -2,7 +2,7 @@ presubmits:
   IBM/ibm-platform-api-operator:
   - name: build_ibm-platform-api-operator
     branches:
-    - ^release-3.8$
+    - ^release-eus$
     labels:
       preset-service-account: "true"
     decorate: true
@@ -22,7 +22,7 @@ presubmits:
     trigger: '(?m)^/test (?:.*? )?build(?: .*?)?$'
   - name: check_ibm-platform-api-operator
     branches:
-    - ^release-3.8$
+    - ^release-eus$
     decorate: true
     always_run: true
     path_alias: github.com/IBM/ibm-platform-api-operator
@@ -39,7 +39,7 @@ presubmits:
     trigger: '(?m)^/test (?:.*? )?check(?: .*?)?$'
   - name: test_ibm-platform-api-operator
     branches:
-    - ^release-3.8$
+    - ^release-eus$
     decorate: true
     always_run: true
     path_alias: github.com/IBM/ibm-platform-api-operator
@@ -60,7 +60,7 @@ postsubmits:
   IBM/ibm-platform-api-operator:
   - name: check_ibm-platform-api-operator_postsubmit
     branches:
-    - ^release-3.8$
+    - ^release-eus$
     decorate: true
     path_alias: github.com/IBM/ibm-platform-api-operator
     spec:
@@ -74,7 +74,7 @@ postsubmits:
           privileged: true
   - name: test_ibm-platform-api-operator_postsubmit
     branches:
-    - ^release-3.8$
+    - ^release-eus$
     decorate: true
     path_alias: github.com/IBM/ibm-platform-api-operator
     spec:
@@ -89,7 +89,7 @@ postsubmits:
           privileged: true
   - name: build_ibm-platform-api-operator_postsubmit
     branches:
-    - ^release-3.8$
+    - ^release-eus$
     labels:
       preset-service-account: "true"
     decorate: true
@@ -106,7 +106,7 @@ postsubmits:
           privileged: true
   - name: images_ibm-platform-api-operator_postsubmit
     branches:
-    - ^release-3.8$
+    - ^release-eus$
     decorate: true
     path_alias: github.com/IBM/ibm-platform-api-operator
     labels:


### PR DESCRIPTION
- release-cd
- release-efix
- release-eus

removed release-3.8 branch from builds

**What this PR does / why we need it**: To work with new CICD pipeline

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Specify your PR reviewers**:
<!-- Add or remove reviewers as your request -->
/cc @gyliu513 @horis233

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
