### PR TITLE
Add specific goal to build latest only on master

### DIFF
--- a/prow/cluster/jobs/IBM/ibm-licensing-operator/IBM.ibm-licensing-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-licensing-operator/IBM.ibm-licensing-operator.master.yaml
@@ -319,3 +319,21 @@ postsubmits:
         name: ""
         securityContext:
           privileged: true
+  - name: multiarch-latest-image-ibm-licensing-postsubmit
+    cluster: default
+    branches:
+    - ^master$
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    path_alias: github.com/IBM/ibm-licensing-operator
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - multiarch-image-latest
+        image: quay.io/multicloudlab/build-tool:v20210728-821884179
+        name: ""
+        securityContext:
+          privileged: true


### PR DESCRIPTION
**What this PR does / why we need it**: 
 Multiarch goal builds latest on every release branch, we want to build it only on master.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/48788

**Specify your PR reviewers**:
<!-- Add or remove reviewers as your request -->
/cc @gyliu513 @horis233

**Special notes for your reviewer**:


