### PR TITLE
Fix branch name in configuration for crossplane-provider-kubernetes

### DIFF
--- a/prow/cluster/jobs/IBM/crossplane-provider-kubernetes/IBM.crossplane-provider-kubernetes.main.yaml
+++ b/prow/cluster/jobs/IBM/crossplane-provider-kubernetes/IBM.crossplane-provider-kubernetes.main.yaml
@@ -2,7 +2,7 @@ presubmits:
   IBM/crossplane-provider-kubernetes:
   - name: build_crossplane-provider-kubernetes
     branches:
-    - ^master$
+    - ^main$
     - ^release-cd$
     - ^release-efix$
     - ^release-eus$
@@ -24,30 +24,9 @@ presubmits:
         securityContext:
           privileged: true
     trigger: '(?m)^/test (?:.*? )?build(?: .*?)?$'
-  - name: check_crossplane-provider-kubernetes
-    branches:
-    - ^master$
-    - ^release-cd$
-    - ^release-efix$
-    - ^release-eus$
-    - ^release-future$
-    decorate: true
-    always_run: true
-    path_alias: github.com/IBM/crossplane-provider-kubernetes
-    rerun_command: /test check crossplane-provider-kubernetes
-    spec:
-      containers:
-      - command:
-        - make
-        - check
-        image: quay.io/multicloudlab/check-tool:v20201120-383f8da3c
-        name: ""
-        securityContext:
-          privileged: true
-    trigger: '(?m)^/test (?:.*? )?check(?: .*?)?$'
   - name: test_crossplane-provider-kubernetes
     branches:
-    - ^master$
+    - ^main$
     - ^release-cd$
     - ^release-efix$
     - ^release-eus$
@@ -70,27 +49,9 @@ presubmits:
 
 postsubmits:
   IBM/crossplane-provider-kubernetes:
-  - name: check_crossplane-provider-kubernetes_postsubmit
-    branches:
-    - ^master$
-    - ^release-cd$
-    - ^release-efix$
-    - ^release-eus$
-    - ^release-future$
-    decorate: true
-    path_alias: github.com/IBM/crossplane-provider-kubernetes
-    spec:
-      containers:
-      - command:
-        - make
-        - check
-        image: quay.io/multicloudlab/check-tool:v20201120-383f8da3c
-        name: ""
-        securityContext:
-          privileged: true
   - name: test_crossplane-provider-kubernetes_postsubmit
     branches:
-    - ^master$
+    - ^main$
     - ^release-cd$
     - ^release-efix$
     - ^release-eus$
@@ -109,7 +70,7 @@ postsubmits:
           privileged: true
   - name: build_crossplane-provider-kubernetes_postsubmit
     branches:
-    - ^master$
+    - ^main$
     - ^release-cd$
     - ^release-efix$
     - ^release-eus$
@@ -130,7 +91,7 @@ postsubmits:
           privileged: true
   - name: images_crossplane-provider-kubernetes_postsubmit
     branches:
-    - ^master$
+    - ^main$
     - ^release-cd$
     - ^release-efix$
     - ^release-eus$


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix branch names in configuration for [`IBM/crossplane-kubernetes-provider`](https://github.com/IBM/crossplane-provider-kubernetes) repo.
Remove `check_crossplane-provider-kubernetes`.

**Specify your PR reviewers**:
<!-- Add or remove reviewers as your request -->
/cc @gyliu513 @horis233

**Special notes for your reviewer**:
https://github.ibm.com/ibmprivatecloud/roadmap/issues/50564

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

