### PR TITLE
Add prow configurations for crossplane providers

### DIFF
--- a/prow/cluster/jobs/IBM/crossplane-provider-ibm-cloud/IBM.crossplane-provider-ibm-cloud.master.yaml
+++ b/prow/cluster/jobs/IBM/crossplane-provider-ibm-cloud/IBM.crossplane-provider-ibm-cloud.master.yaml
@@ -1,0 +1,113 @@
+presubmits:
+  IBM/crossplane-provider-ibm-cloud:
+  - name: build_crossplane-provider-ibm-cloud
+    branches:
+    - ^master$
+    - ^release-cd$
+    - ^release-efix$
+    - ^release-eus$
+    - ^release-future$
+    labels:
+      preset-service-account: "true"
+    decorate: true
+    always_run: true
+    path_alias: github.com/IBM/crossplane-provider-ibm-cloud
+    rerun_command: /test build crossplane-provider-ibm-cloud
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - build
+        image: quay.io/multicloudlab/build-tool:v20210203-ad22dc7f6
+        name: ""
+        securityContext:
+          privileged: true
+    trigger: '(?m)^/test (?:.*? )?build(?: .*?)?$'
+  - name: test_crossplane-provider-ibm-cloud
+    branches:
+    - ^master$
+    - ^release-cd$
+    - ^release-efix$
+    - ^release-eus$
+    - ^release-future$
+    decorate: true
+    always_run: true
+    path_alias: github.com/IBM/crossplane-provider-ibm-cloud
+    rerun_command: /test test crossplane-provider-ibm-cloud
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - test
+        image: quay.io/multicloudlab/build-tool:v20210203-ad22dc7f6
+        name: ""
+        securityContext:
+          privileged: true
+    trigger: '(?m)^/test (?:.*? )?test(?: .*?)?$'
+
+postsubmits:
+  IBM/crossplane-provider-ibm-cloud:
+  - name: test_crossplane-provider-ibm-cloud_postsubmit
+    branches:
+    - ^master$
+    - ^release-cd$
+    - ^release-efix$
+    - ^release-eus$
+    - ^release-future$
+    decorate: true
+    path_alias: github.com/IBM/crossplane-provider-ibm-cloud
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - test
+        image: quay.io/multicloudlab/build-tool:v20210203-ad22dc7f6
+        name: ""
+        securityContext:
+          privileged: true
+  - name: build_crossplane-provider-ibm-cloud_postsubmit
+    branches:
+    - ^master$
+    - ^release-cd$
+    - ^release-efix$
+    - ^release-eus$
+    - ^release-future$
+    labels:
+      preset-service-account: "true"
+    decorate: true
+    path_alias: github.com/IBM/crossplane-provider-ibm-cloud
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - build
+        image: quay.io/multicloudlab/build-tool:v20210203-ad22dc7f6
+        name: ""
+        securityContext:
+          privileged: true
+  - name: images_crossplane-provider-ibm-cloud_postsubmit
+    branches:
+    - ^master$
+    - ^release-cd$
+    - ^release-efix$
+    - ^release-eus$
+    - ^release-future$
+    decorate: true
+    path_alias: github.com/IBM/crossplane-provider-ibm-cloud
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - command:
+        - entrypoint
+        - make
+        - images
+        image: quay.io/multicloudlab/build-tool:v20210203-ad22dc7f6
+        name: ""
+        securityContext:
+          privileged: true
+

--- a/prow/cluster/jobs/IBM/crossplane-provider-kubernetes/IBM.crossplane-provider-kubernetes.main.yaml
+++ b/prow/cluster/jobs/IBM/crossplane-provider-kubernetes/IBM.crossplane-provider-kubernetes.main.yaml
@@ -2,7 +2,7 @@ presubmits:
   IBM/crossplane-provider-kubernetes:
   - name: build_crossplane-provider-kubernetes
     branches:
-    - ^master$
+    - ^main$
     - ^release-cd$
     - ^release-efix$
     - ^release-eus$
@@ -24,30 +24,9 @@ presubmits:
         securityContext:
           privileged: true
     trigger: '(?m)^/test (?:.*? )?build(?: .*?)?$'
-  - name: check_crossplane-provider-kubernetes
-    branches:
-    - ^master$
-    - ^release-cd$
-    - ^release-efix$
-    - ^release-eus$
-    - ^release-future$
-    decorate: true
-    always_run: true
-    path_alias: github.com/IBM/crossplane-provider-kubernetes
-    rerun_command: /test check crossplane-provider-kubernetes
-    spec:
-      containers:
-      - command:
-        - make
-        - check
-        image: quay.io/multicloudlab/check-tool:v20201120-383f8da3c
-        name: ""
-        securityContext:
-          privileged: true
-    trigger: '(?m)^/test (?:.*? )?check(?: .*?)?$'
   - name: test_crossplane-provider-kubernetes
     branches:
-    - ^master$
+    - ^main$
     - ^release-cd$
     - ^release-efix$
     - ^release-eus$
@@ -70,27 +49,9 @@ presubmits:
 
 postsubmits:
   IBM/crossplane-provider-kubernetes:
-  - name: check_crossplane-provider-kubernetes_postsubmit
-    branches:
-    - ^master$
-    - ^release-cd$
-    - ^release-efix$
-    - ^release-eus$
-    - ^release-future$
-    decorate: true
-    path_alias: github.com/IBM/crossplane-provider-kubernetes
-    spec:
-      containers:
-      - command:
-        - make
-        - check
-        image: quay.io/multicloudlab/check-tool:v20201120-383f8da3c
-        name: ""
-        securityContext:
-          privileged: true
   - name: test_crossplane-provider-kubernetes_postsubmit
     branches:
-    - ^master$
+    - ^main$
     - ^release-cd$
     - ^release-efix$
     - ^release-eus$
@@ -109,7 +70,7 @@ postsubmits:
           privileged: true
   - name: build_crossplane-provider-kubernetes_postsubmit
     branches:
-    - ^master$
+    - ^main$
     - ^release-cd$
     - ^release-efix$
     - ^release-eus$
@@ -130,7 +91,7 @@ postsubmits:
           privileged: true
   - name: images_crossplane-provider-kubernetes_postsubmit
     branches:
-    - ^master$
+    - ^main$
     - ^release-cd$
     - ^release-efix$
     - ^release-eus$

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -33,8 +33,9 @@ tide:
     IBM/ibm-common-service-operator: squash
     IBM/ibm-namespace-scope-operator: squash
     IBM/ibm-common-service-webhook: squash
-    IBM/ibm-crossplane: squash
     IBM/ibm-crossplane-operator: squash
+    IBM/crossplane-provider-kubernetes: squash
+    IBM/crossplane-provider-ibm-cloud: squash
     IBM/ibm-elastic-stack-operator: squash
     IBM/ibm-grafana-ocpthanos-proxy: squash
     IBM/ibm-monitoring-grafana-operator: squash
@@ -96,8 +97,9 @@ tide:
     - IBM/ibm-common-service-operator
     - IBM/ibm-namespace-scope-operator
     - IBM/ibm-common-service-webhook
-    - IBM/ibm-crossplane
     - IBM/ibm-crossplane-operator
+    - IBM/crossplane-provider-kubernetes
+    - IBM/crossplane-provider-ibm-cloud
     - IBM/ibm-elastic-stack-operator
     - IBM/ibm-grafana-ocpthanos-proxy
     - IBM/ibm-monitoring-grafana-operator


### PR DESCRIPTION
**What this PR does / why we need it**:
Create prow build configuration for [IBM/crossplane-provider-ibm-cloud](https://github.com/IBM/crossplane-provider-ibm-cloud) repo.
Fix mismatchen branch names in configuration for [IBM/crossplane-provider-kubernetes](https://github.com/IBM/crossplane-provider-kubernetes) repo.
Add crossplane provider configurations to config.yaml

**Specify your PR reviewers**:
<!-- Add or remove reviewers as your request -->
/cc @gyliu513 @horis233

**Special notes for your reviewer**:
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/51087
https://github.ibm.com/ibmprivatecloud/roadmap/issues/50564

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
