### PR TITLE
Bump Go version to 1.16.6 for Crossplane Providers

### DIFF
--- a/prow/cluster/jobs/IBM/crossplane-provider-ibm-cloud/IBM.crossplane-provider-ibm-cloud.master.yaml
+++ b/prow/cluster/jobs/IBM/crossplane-provider-ibm-cloud/IBM.crossplane-provider-ibm-cloud.master.yaml
@@ -22,7 +22,7 @@ presubmits:
         env:
         - name: RUNNING_IN_CI
           value: "true"
-        image: quay.io/multicloudlab/build-tool:v20210203-ad22dc7f6
+        image: quay.io/multicloudlab/build-tool:v20210728-821884179
         name: ""
         securityContext:
           privileged: true
@@ -47,7 +47,7 @@ presubmits:
         env:
         - name: RUNNING_IN_CI
           value: "true"
-        image: quay.io/multicloudlab/build-tool:v20210203-ad22dc7f6
+        image: quay.io/multicloudlab/build-tool:v20210728-821884179
         name: ""
         securityContext:
           privileged: true
@@ -73,7 +73,7 @@ postsubmits:
         env:
         - name: RUNNING_IN_CI
           value: "true"
-        image: quay.io/multicloudlab/build-tool:v20210203-ad22dc7f6
+        image: quay.io/multicloudlab/build-tool:v20210728-821884179
         name: ""
         securityContext:
           privileged: true
@@ -97,7 +97,7 @@ postsubmits:
         env:
         - name: RUNNING_IN_CI
           value: "true"
-        image: quay.io/multicloudlab/build-tool:v20210203-ad22dc7f6
+        image: quay.io/multicloudlab/build-tool:v20210728-821884179
         name: ""
         securityContext:
           privileged: true
@@ -121,7 +121,7 @@ postsubmits:
         env:
         - name: RUNNING_IN_CI
           value: "true"
-        image: quay.io/multicloudlab/build-tool:v20210203-ad22dc7f6
+        image: quay.io/multicloudlab/build-tool:v20210728-821884179
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/crossplane-provider-kubernetes/IBM.crossplane-provider-kubernetes.master.yaml
+++ b/prow/cluster/jobs/IBM/crossplane-provider-kubernetes/IBM.crossplane-provider-kubernetes.master.yaml
@@ -22,7 +22,7 @@ presubmits:
         env:
         - name: RUNNING_IN_CI
           value: "true"
-        image: quay.io/multicloudlab/build-tool:v20210203-ad22dc7f6
+        image: quay.io/multicloudlab/build-tool:v20210728-821884179
         name: ""
         securityContext:
           privileged: true
@@ -47,7 +47,7 @@ presubmits:
         env:
         - name: RUNNING_IN_CI
           value: "true"
-        image: quay.io/multicloudlab/build-tool:v20210203-ad22dc7f6
+        image: quay.io/multicloudlab/build-tool:v20210728-821884179
         name: ""
         securityContext:
           privileged: true
@@ -73,7 +73,7 @@ postsubmits:
         env:
         - name: RUNNING_IN_CI
           value: "true"
-        image: quay.io/multicloudlab/build-tool:v20210203-ad22dc7f6
+        image: quay.io/multicloudlab/build-tool:v20210728-821884179
         name: ""
         securityContext:
           privileged: true
@@ -97,7 +97,7 @@ postsubmits:
         env:
         - name: RUNNING_IN_CI
           value: "true"
-        image: quay.io/multicloudlab/build-tool:v20210203-ad22dc7f6
+        image: quay.io/multicloudlab/build-tool:v20210728-821884179
         name: ""
         securityContext:
           privileged: true
@@ -121,7 +121,7 @@ postsubmits:
         env:
         - name: RUNNING_IN_CI
           value: "true"
-        image: quay.io/multicloudlab/build-tool:v20210203-ad22dc7f6
+        image: quay.io/multicloudlab/build-tool:v20210728-821884179
         name: ""
         securityContext:
           privileged: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Prow builds fail due to older Go version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes 
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/51354
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/50564

**Specify your PR reviewers**:
<!-- Add or remove reviewers as your request -->
/cc @gyliu513 @horis233

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
