### PR TITLE
bump check-tool in crossplane

### DIFF
--- a/prow/cluster/jobs/IBM/ibm-crossplane-operator/IBM.ibm-crossplane-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-crossplane-operator/IBM.ibm-crossplane-operator.master.yaml
@@ -42,7 +42,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20220105-f9f161e03
+        image: quay.io/multicloudlab/check-tool:v20220928-7733fc2f9
         name: ""
         securityContext:
           privileged: true


### PR DESCRIPTION
**What this PR does / why we need it**:

`check_ibm-crossplane-operator_postsubmit` job in https://github.com/IBM/ibm-crossplane-operator is constantly failing due to not being able to pull image of check-tool - this commit is bumping tag of check-tool image

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Specify your PR reviewers**:
<!-- Add or remove reviewers as your request -->
/cc @gyliu513 @horis233

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
