### PR TITLE
Disable EUS branch of nginx as test

### DIFF
--- a/prow/cluster/jobs/IBM/ibm-ingress-nginx-operator/IBM.ibm-ingress-nginx-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-ingress-nginx-operator/IBM.ibm-ingress-nginx-operator.master.yaml
@@ -7,7 +7,6 @@ presubmits:
     - ^master$
     - ^release-cd$
     - ^release-efix$
-    - ^release-eus$
     - ^release-ltsr$
     decorate: true
     path_alias: github.com/IBM/ibm-ingress-nginx-operator
@@ -28,7 +27,6 @@ presubmits:
     branches:
     - ^master$
     - ^release-efix$
-    - ^release-eus$
     - ^release-future$
     - ^release-ltsr$
     decorate: true
@@ -51,7 +49,6 @@ presubmits:
     branches:
     - ^master$
     - ^release-efix$
-    - ^release-eus$
     - ^release-future$
     - ^release-ltsr$
     decorate: true
@@ -76,7 +73,6 @@ presubmits:
     branches:
     - ^master$
     - ^release-efix$
-    - ^release-eus$
     - ^release-future$
     - ^release-ltsr$
     decorate: true
@@ -101,7 +97,6 @@ presubmits:
     branches:
     - ^master$
     - ^release-efix$
-    - ^release-eus$
     - ^release-future$
     - ^release-ltsr$
     decorate: true
@@ -127,7 +122,6 @@ postsubmits:
     branches:
     - ^master$
     - ^release-efix$
-    - ^release-eus$
     - ^release-future$
     - ^release-ltsr$
     decorate: true
@@ -149,7 +143,6 @@ postsubmits:
     branches:
     - ^master$
     - ^release-efix$
-    - ^release-eus$
     - ^release-future$
     - ^release-ltsr$
     decorate: true
@@ -171,7 +164,6 @@ postsubmits:
     branches:
     - ^master$
     - ^release-efix$
-    - ^release-eus$
     - ^release-future$
     - ^release-ltsr$
     decorate: true
@@ -193,7 +185,6 @@ postsubmits:
     branches:
     - ^master$
     - ^release-efix$
-    - ^release-eus$
     - ^release-future$
     - ^release-ltsr$
     decorate: true


### PR DESCRIPTION
This PR will remove the EUS branch from build defintions of nginx ingress.  This should be fine as EUS is now out of support, but is mainly being done as a test to verify connection to new prow server.
