### PR TITLE
global update tools images - operators

### DIFF
--- a/prow/cluster/jobs/IBM/crossplane-provider-ibm-cloud/IBM.crossplane-provider-ibm-cloud.master.yaml
+++ b/prow/cluster/jobs/IBM/crossplane-provider-ibm-cloud/IBM.crossplane-provider-ibm-cloud.master.yaml
@@ -23,7 +23,7 @@ presubmits:
         env:
         - name: RUNNING_IN_CI
           value: "true"
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -49,7 +49,7 @@ presubmits:
         env:
         - name: RUNNING_IN_CI
           value: "true"
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -76,7 +76,7 @@ postsubmits:
         env:
         - name: RUNNING_IN_CI
           value: "true"
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -101,7 +101,7 @@ postsubmits:
         env:
         - name: RUNNING_IN_CI
           value: "true"
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -126,7 +126,7 @@ postsubmits:
         env:
         - name: RUNNING_IN_CI
           value: "true"
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/crossplane-provider-kubernetes/IBM.crossplane-provider-kubernetes.master.yaml
+++ b/prow/cluster/jobs/IBM/crossplane-provider-kubernetes/IBM.crossplane-provider-kubernetes.master.yaml
@@ -23,7 +23,7 @@ presubmits:
         env:
         - name: RUNNING_IN_CI
           value: "true"
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -49,7 +49,7 @@ presubmits:
         env:
         - name: RUNNING_IN_CI
           value: "true"
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -76,7 +76,7 @@ postsubmits:
         env:
         - name: RUNNING_IN_CI
           value: "true"
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -101,7 +101,7 @@ postsubmits:
         env:
         - name: RUNNING_IN_CI
           value: "true"
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -126,7 +126,7 @@ postsubmits:
         env:
         - name: RUNNING_IN_CI
           value: "true"
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/deployer-operator/ibm.deployer-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/deployer-operator/ibm.deployer-operator.master.yaml
@@ -13,7 +13,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -107,7 +107,7 @@ postsubmits:
       - command:
         - make
         - coverage
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         env:
         - name: CODECOV_TOKEN

--- a/prow/cluster/jobs/IBM/go-repo-template/ibm.go-repo-template-release-1.1.yaml
+++ b/prow/cluster/jobs/IBM/go-repo-template/ibm.go-repo-template-release-1.1.yaml
@@ -13,7 +13,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -32,7 +32,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -51,7 +51,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -70,7 +70,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -89,7 +89,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -108,7 +108,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -127,7 +127,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -145,7 +145,7 @@ postsubmits:
       - command:
         - make
         - coverage
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         env:
         - name: CODECOV_TOKEN
@@ -167,7 +167,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -183,7 +183,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -199,7 +199,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -217,7 +217,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -235,7 +235,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -253,7 +253,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -271,7 +271,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/go-repo-template/ibm.go-repo-template.master.yaml
+++ b/prow/cluster/jobs/IBM/go-repo-template/ibm.go-repo-template.master.yaml
@@ -13,7 +13,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -145,7 +145,7 @@ postsubmits:
       - command:
         - make
         - coverage
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         env:
         - name: CODECOV_TOKEN

--- a/prow/cluster/jobs/IBM/ibm-auditlogging-operator/IBM.ibm-auditlogging-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-auditlogging-operator/IBM.ibm-auditlogging-operator.master.yaml
@@ -17,7 +17,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -38,7 +38,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -60,7 +60,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -82,7 +82,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -101,7 +101,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -120,7 +120,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -141,7 +141,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-auditlogging-operator/IBM.ibm-auditlogging-operator.release-3.8.yaml
+++ b/prow/cluster/jobs/IBM/ibm-auditlogging-operator/IBM.ibm-auditlogging-operator.release-3.8.yaml
@@ -13,7 +13,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -30,7 +30,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -48,7 +48,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -66,7 +66,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -81,7 +81,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -96,7 +96,7 @@ postsubmits:
         - entrypoint
         - make
         - coverage
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         env:
         - name: CODECOV_TOKEN
@@ -117,7 +117,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -134,7 +134,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-catalog-ui-operator/IBM.ibm-catalog-ui-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-catalog-ui-operator/IBM.ibm-catalog-ui-operator.master.yaml
@@ -30,7 +30,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -50,7 +50,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -84,7 +84,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -101,7 +101,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-cert-manager-operator/IBM.ibm-cert-manager-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-cert-manager-operator/IBM.ibm-cert-manager-operator.master.yaml
@@ -18,7 +18,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -40,7 +40,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -63,7 +63,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -86,7 +86,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -106,7 +106,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -126,7 +126,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -148,7 +148,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-common-service-operator/IBM.ibm-common-service-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-common-service-operator/IBM.ibm-common-service-operator.master.yaml
@@ -18,7 +18,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -42,7 +42,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -66,7 +66,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -90,7 +90,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -116,7 +116,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -139,7 +139,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -162,7 +162,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -185,7 +185,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-common-service-operator/IBM.ibm-common-service-operator.release-3.6.yaml
+++ b/prow/cluster/jobs/IBM/ibm-common-service-operator/IBM.ibm-common-service-operator.release-3.6.yaml
@@ -13,7 +13,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -32,7 +32,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -51,7 +51,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -70,7 +70,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -91,7 +91,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -109,7 +109,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -127,7 +127,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -145,7 +145,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-common-service-operator/IBM.ibm-common-service-operator.release-3.7.yaml
+++ b/prow/cluster/jobs/IBM/ibm-common-service-operator/IBM.ibm-common-service-operator.release-3.7.yaml
@@ -13,7 +13,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -32,7 +32,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -51,7 +51,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -70,7 +70,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -91,7 +91,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -109,7 +109,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -127,7 +127,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -145,7 +145,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-common-service-operator/IBM.ibm-common-service-operator.release-4.0.yaml
+++ b/prow/cluster/jobs/IBM/ibm-common-service-operator/IBM.ibm-common-service-operator.release-4.0.yaml
@@ -13,7 +13,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -32,7 +32,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -51,7 +51,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -70,7 +70,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -91,7 +91,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -109,7 +109,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -127,7 +127,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -145,7 +145,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-common-service-webhook/IBM.ibm-common-service-webhook.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-common-service-webhook/IBM.ibm-common-service-webhook.master.yaml
@@ -17,7 +17,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -40,7 +40,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -63,7 +63,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -86,7 +86,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -109,7 +109,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -132,7 +132,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -155,7 +155,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -178,7 +178,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -198,7 +198,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -218,7 +218,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -240,7 +240,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -262,7 +262,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -284,7 +284,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -306,7 +306,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-common-service-webhook/IBM.ibm-common-service-webhook.release-1.2.yaml
+++ b/prow/cluster/jobs/IBM/ibm-common-service-webhook/IBM.ibm-common-service-webhook.release-1.2.yaml
@@ -13,7 +13,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -32,7 +32,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -51,7 +51,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -70,7 +70,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -89,7 +89,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -108,7 +108,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -127,7 +127,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -145,7 +145,7 @@ postsubmits:
       - command:
         - make
         - coverage
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         env:
         - name: CODECOV_TOKEN
@@ -167,7 +167,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -183,7 +183,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -199,7 +199,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -217,7 +217,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -235,7 +235,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -253,7 +253,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -271,7 +271,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-common-service-webhook/IBM.ibm-common-service-webhook.release-1.3.yaml
+++ b/prow/cluster/jobs/IBM/ibm-common-service-webhook/IBM.ibm-common-service-webhook.release-1.3.yaml
@@ -13,7 +13,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -32,7 +32,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -51,7 +51,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -70,7 +70,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -89,7 +89,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -108,7 +108,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -127,7 +127,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -145,7 +145,7 @@ postsubmits:
       - command:
         - make
         - coverage
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         env:
         - name: CODECOV_TOKEN
@@ -167,7 +167,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -183,7 +183,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -199,7 +199,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -217,7 +217,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -235,7 +235,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -253,7 +253,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -271,7 +271,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-commonui-operator/IBM.ibm-commonui-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-commonui-operator/IBM.ibm-commonui-operator.master.yaml
@@ -18,7 +18,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -40,7 +40,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -63,7 +63,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -86,7 +86,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -106,7 +106,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -126,7 +126,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -148,7 +148,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-commonui-operator/IBM.ibm-commonui-operator.release-1.4.yaml
+++ b/prow/cluster/jobs/IBM/ibm-commonui-operator/IBM.ibm-commonui-operator.release-1.4.yaml
@@ -13,7 +13,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -30,7 +30,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -48,7 +48,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -66,7 +66,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -81,7 +81,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -95,7 +95,7 @@ postsubmits:
       - command:
         - make
         - coverage
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         env:
         - name: CODECOV_TOKEN
@@ -116,7 +116,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -133,7 +133,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-commonui-operator/IBM.ibm-commonui-operator.release-1.5.yaml
+++ b/prow/cluster/jobs/IBM/ibm-commonui-operator/IBM.ibm-commonui-operator.release-1.5.yaml
@@ -13,7 +13,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -30,7 +30,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -48,7 +48,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -66,7 +66,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -81,7 +81,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -95,7 +95,7 @@ postsubmits:
       - command:
         - make
         - coverage
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         env:
         - name: CODECOV_TOKEN
@@ -116,7 +116,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -133,7 +133,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-crossplane-operator/IBM.ibm-crossplane-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-crossplane-operator/IBM.ibm-crossplane-operator.master.yaml
@@ -20,7 +20,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -42,7 +42,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -65,7 +65,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -88,7 +88,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -108,7 +108,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -130,7 +130,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -152,7 +152,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-elastic-stack-operator/IBM.ibm-elastic-stack-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-elastic-stack-operator/IBM.ibm-elastic-stack-operator.master.yaml
@@ -32,7 +32,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -51,7 +51,7 @@ presubmits:
         - entrypoint
         - make
         - build-image-amd64
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -70,7 +70,7 @@ presubmits:
         - entrypoint
         - make
         - build-image-ppc64le
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -89,7 +89,7 @@ presubmits:
         - entrypoint
         - make
         - build-image-s390x
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -131,7 +131,7 @@ postsubmits:
         - entrypoint
         - make
         - push-image-amd64
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -149,7 +149,7 @@ postsubmits:
         - entrypoint
         - make
         - push-image-ppc64le
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -167,7 +167,7 @@ postsubmits:
         - entrypoint
         - make
         - push-image-s390x
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -185,7 +185,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-elastic-stack-operator/IBM.ibm-elastic-stack-operator.release-v3.1.5.yaml
+++ b/prow/cluster/jobs/IBM/ibm-elastic-stack-operator/IBM.ibm-elastic-stack-operator.release-v3.1.5.yaml
@@ -15,7 +15,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -50,7 +50,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -83,7 +83,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -120,7 +120,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -137,7 +137,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-grafana-ocpthanos-proxy/IBM.ibm-grafana-ocpthanos-proxy.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-grafana-ocpthanos-proxy/IBM.ibm-grafana-ocpthanos-proxy.master.yaml
@@ -13,7 +13,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -145,7 +145,7 @@ postsubmits:
       - command:
         - make
         - coverage
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         env:
         - name: CODECOV_TOKEN

--- a/prow/cluster/jobs/IBM/ibm-healthcheck-operator/IBM.ibm-healthcheck-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-healthcheck-operator/IBM.ibm-healthcheck-operator.master.yaml
@@ -17,7 +17,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -40,7 +40,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -63,7 +63,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -86,7 +86,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -109,7 +109,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -132,7 +132,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -155,7 +155,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -178,7 +178,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -198,7 +198,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -218,7 +218,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -240,7 +240,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -262,7 +262,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -284,7 +284,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -306,7 +306,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-healthcheck-operator/IBM.ibm-healthcheck-operator.release-3.8.yaml
+++ b/prow/cluster/jobs/IBM/ibm-healthcheck-operator/IBM.ibm-healthcheck-operator.release-3.8.yaml
@@ -13,7 +13,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -32,7 +32,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -51,7 +51,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -70,7 +70,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -89,7 +89,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -108,7 +108,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -127,7 +127,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -145,7 +145,7 @@ postsubmits:
       - command:
         - make
         - coverage
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         env:
         - name: CODECOV_TOKEN
@@ -167,7 +167,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -183,7 +183,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -199,7 +199,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -217,7 +217,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -235,7 +235,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -253,7 +253,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -271,7 +271,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-helm-api-operator/IBM.ibm-helm-api-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-helm-api-operator/IBM.ibm-helm-api-operator.master.yaml
@@ -30,7 +30,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -50,7 +50,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -84,7 +84,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -101,7 +101,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-helm-repo-operator/IBM.ibm-helm-repo-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-helm-repo-operator/IBM.ibm-helm-repo-operator.master.yaml
@@ -30,7 +30,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -50,7 +50,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -84,7 +84,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -101,7 +101,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-iam-operator/IBM.ibm-iam-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-iam-operator/IBM.ibm-iam-operator.master.yaml
@@ -19,7 +19,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -42,7 +42,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -66,7 +66,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -90,7 +90,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -111,7 +111,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -132,7 +132,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -155,7 +155,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-iam-operator/IBM.ibm-iam-operator.release-3.7.yaml
+++ b/prow/cluster/jobs/IBM/ibm-iam-operator/IBM.ibm-iam-operator.release-3.7.yaml
@@ -13,7 +13,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -30,7 +30,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -48,7 +48,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -66,7 +66,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -81,7 +81,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -95,7 +95,7 @@ postsubmits:
       - command:
         - make
         - coverage
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         env:
         - name: CODECOV_TOKEN
@@ -116,7 +116,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -133,7 +133,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-iam-operator/IBM.ibm-iam-operator.release-3.8.yaml
+++ b/prow/cluster/jobs/IBM/ibm-iam-operator/IBM.ibm-iam-operator.release-3.8.yaml
@@ -13,7 +13,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -30,7 +30,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -48,7 +48,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -66,7 +66,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -81,7 +81,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -95,7 +95,7 @@ postsubmits:
       - command:
         - make
         - coverage
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         env:
         - name: CODECOV_TOKEN
@@ -116,7 +116,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -133,7 +133,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-iam-operator/IBM.ibm-iam-operator.release-3.9.yaml
+++ b/prow/cluster/jobs/IBM/ibm-iam-operator/IBM.ibm-iam-operator.release-3.9.yaml
@@ -13,7 +13,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -30,7 +30,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -48,7 +48,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -66,7 +66,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -81,7 +81,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -95,7 +95,7 @@ postsubmits:
       - command:
         - make
         - coverage
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         env:
         - name: CODECOV_TOKEN
@@ -116,7 +116,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -133,7 +133,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-iam-policy-operator/IBM.ibm-iam-policy-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-iam-policy-operator/IBM.ibm-iam-policy-operator.master.yaml
@@ -15,7 +15,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -34,7 +34,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -54,7 +54,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -74,7 +74,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -91,7 +91,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -108,7 +108,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -127,7 +127,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-ingress-nginx-operator/IBM.ibm-ingress-nginx-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-ingress-nginx-operator/IBM.ibm-ingress-nginx-operator.master.yaml
@@ -16,7 +16,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -38,7 +38,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -62,7 +62,7 @@ presubmits:
         - entrypoint
         - make
         - build-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -86,7 +86,7 @@ presubmits:
         - entrypoint
         - make
         - build-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -110,7 +110,7 @@ presubmits:
         - entrypoint
         - make
         - build-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -134,7 +134,7 @@ postsubmits:
         - entrypoint
         - make
         - push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -155,7 +155,7 @@ postsubmits:
         - entrypoint
         - make
         - push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -176,7 +176,7 @@ postsubmits:
         - entrypoint
         - make
         - push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -197,7 +197,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-licensing-hub-operator/IBM.ibm-licensing-hub-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-licensing-hub-operator/IBM.ibm-licensing-hub-operator.master.yaml
@@ -13,7 +13,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -32,7 +32,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -51,7 +51,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -70,7 +70,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -89,7 +89,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -108,7 +108,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -127,7 +127,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -146,7 +146,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -162,7 +162,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -178,7 +178,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true        
@@ -196,7 +196,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -214,7 +214,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -232,7 +232,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true         
@@ -250,7 +250,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-licensing-operator/IBM.ibm-licensing-operator.development.yaml
+++ b/prow/cluster/jobs/IBM/ibm-licensing-operator/IBM.ibm-licensing-operator.development.yaml
@@ -20,7 +20,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image-development
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -44,7 +44,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image-development
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -68,7 +68,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image-development
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -92,7 +92,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image-development
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-licensing-operator/IBM.ibm-licensing-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-licensing-operator/IBM.ibm-licensing-operator.master.yaml
@@ -21,7 +21,7 @@ presubmits:
         - entrypoint
         - make
         - build-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -47,7 +47,7 @@ presubmits:
         - entrypoint
         - make
         - build-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -73,7 +73,7 @@ presubmits:
         - entrypoint
         - make
         - build-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -99,7 +99,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -121,7 +121,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -143,7 +143,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true         
@@ -165,7 +165,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -183,7 +183,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image-latest
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-management-ingress-operator/IBM.ibm-management-ingress-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-management-ingress-operator/IBM.ibm-management-ingress-operator.master.yaml
@@ -18,7 +18,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -42,7 +42,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -66,7 +66,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -90,7 +90,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -114,7 +114,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -138,7 +138,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -162,7 +162,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -186,7 +186,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -207,7 +207,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -228,7 +228,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -251,7 +251,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -274,7 +274,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -297,7 +297,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -320,7 +320,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-management-repo-operator/IBM.ibm-management-repo-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-management-repo-operator/IBM.ibm-management-repo-operator.master.yaml
@@ -32,7 +32,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -49,7 +49,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-metering-multicloudui-operator/IBM.ibm-metering-multicloudui-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-metering-multicloudui-operator/IBM.ibm-metering-multicloudui-operator.master.yaml
@@ -13,7 +13,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -30,7 +30,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -48,7 +48,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -66,7 +66,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -81,7 +81,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -96,7 +96,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -113,7 +113,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-metering-operator/IBM.ibm-metering-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-metering-operator/IBM.ibm-metering-operator.master.yaml
@@ -17,7 +17,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -38,7 +38,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -60,7 +60,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -82,7 +82,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -101,7 +101,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -120,7 +120,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -141,7 +141,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-metering-operator/IBM.ibm-metering-operator.release-3.7.yaml
+++ b/prow/cluster/jobs/IBM/ibm-metering-operator/IBM.ibm-metering-operator.release-3.7.yaml
@@ -13,7 +13,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -30,7 +30,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -48,7 +48,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -66,7 +66,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -81,7 +81,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -95,7 +95,7 @@ postsubmits:
       - command:
         - make
         - coverage
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         env:
         - name: CODECOV_TOKEN
@@ -116,7 +116,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -133,7 +133,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-metering-operator/IBM.ibm-metering-operator.release-3.8.yaml
+++ b/prow/cluster/jobs/IBM/ibm-metering-operator/IBM.ibm-metering-operator.release-3.8.yaml
@@ -13,7 +13,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -30,7 +30,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -48,7 +48,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -66,7 +66,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -81,7 +81,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -95,7 +95,7 @@ postsubmits:
       - command:
         - make
         - coverage
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         env:
         - name: CODECOV_TOKEN
@@ -116,7 +116,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -133,7 +133,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-metering-receiver-operator/IBM.ibm-metering-receiver-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-metering-receiver-operator/IBM.ibm-metering-receiver-operator.master.yaml
@@ -13,7 +13,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -30,7 +30,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -48,7 +48,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -66,7 +66,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -81,7 +81,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -95,7 +95,7 @@ postsubmits:
       - command:
         - make
         - coverage
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         env:
         - name: CODECOV_TOKEN
@@ -116,7 +116,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -133,7 +133,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-metering-sender-operator/IBM.ibm-metering-sender-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-metering-sender-operator/IBM.ibm-metering-sender-operator.master.yaml
@@ -13,7 +13,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -30,7 +30,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -48,7 +48,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -66,7 +66,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -81,7 +81,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -95,7 +95,7 @@ postsubmits:
       - command:
         - make
         - coverage
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         env:
         - name: CODECOV_TOKEN
@@ -116,7 +116,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -133,7 +133,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-mongodb-operator/IBM.ibm-mongodb-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-mongodb-operator/IBM.ibm-mongodb-operator.master.yaml
@@ -18,7 +18,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -36,7 +36,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -59,7 +59,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -82,7 +82,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -102,7 +102,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -122,7 +122,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -144,7 +144,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-mongodb-operator/IBM.ibm-mongodb-operator.release-1.2.yaml
+++ b/prow/cluster/jobs/IBM/ibm-mongodb-operator/IBM.ibm-mongodb-operator.release-1.2.yaml
@@ -13,7 +13,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -30,7 +30,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -48,7 +48,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -66,7 +66,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -81,7 +81,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -95,7 +95,7 @@ postsubmits:
       - command:
         - make
         - coverage
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         env:
         - name: CODECOV_TOKEN
@@ -116,7 +116,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -133,7 +133,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-mongodb-operator/IBM.ibm-mongodb-operator.release-1.3.yaml
+++ b/prow/cluster/jobs/IBM/ibm-mongodb-operator/IBM.ibm-mongodb-operator.release-1.3.yaml
@@ -13,7 +13,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -30,7 +30,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -48,7 +48,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -66,7 +66,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -81,7 +81,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -95,7 +95,7 @@ postsubmits:
       - command:
         - make
         - coverage
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         env:
         - name: CODECOV_TOKEN
@@ -116,7 +116,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -133,7 +133,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-monitoring-exporters-operator/IBM.ibm-monitoring-exporters-operator.eus.yaml
+++ b/prow/cluster/jobs/IBM/ibm-monitoring-exporters-operator/IBM.ibm-monitoring-exporters-operator.eus.yaml
@@ -14,7 +14,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -32,7 +32,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -51,7 +51,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -70,7 +70,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -86,7 +86,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -102,7 +102,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -120,7 +120,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-monitoring-exporters-operator/IBM.ibm-monitoring-exporters-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-monitoring-exporters-operator/IBM.ibm-monitoring-exporters-operator.master.yaml
@@ -16,7 +16,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -36,7 +36,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -57,7 +57,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -78,7 +78,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -96,7 +96,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -114,7 +114,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -134,7 +134,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-monitoring-grafana-operator/IBM.ibm-monitoring-grafana-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-monitoring-grafana-operator/IBM.ibm-monitoring-grafana-operator.master.yaml
@@ -22,7 +22,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -75,7 +75,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -125,7 +125,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -149,7 +149,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -174,7 +174,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-monitoring-grafana-operator/IBM.ibm-monitoring-grafana-operator.release-1.11.yaml
+++ b/prow/cluster/jobs/IBM/ibm-monitoring-grafana-operator/IBM.ibm-monitoring-grafana-operator.release-1.11.yaml
@@ -18,7 +18,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -63,7 +63,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -105,7 +105,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -125,7 +125,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -146,7 +146,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-monitoring-prometheus-operator-ext:/IBM.ibm-monitoring-prometheus-operator-ext.eus.yaml
+++ b/prow/cluster/jobs/IBM/ibm-monitoring-prometheus-operator-ext:/IBM.ibm-monitoring-prometheus-operator-ext.eus.yaml
@@ -14,7 +14,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -32,7 +32,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -51,7 +51,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -70,7 +70,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -86,7 +86,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -102,7 +102,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -120,7 +120,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-monitoring-prometheus-operator-ext:/IBM.ibm-monitoring-prometheus-operator-ext.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-monitoring-prometheus-operator-ext:/IBM.ibm-monitoring-prometheus-operator-ext.master.yaml
@@ -16,7 +16,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -36,7 +36,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -57,7 +57,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -78,7 +78,7 @@ postsubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -96,7 +96,7 @@ postsubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -114,7 +114,7 @@ postsubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -134,7 +134,7 @@ postsubmits:
         - entrypoint
         - make
         - images
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-namespace-scope-operator/IBM.ibm-namespace-scope-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-namespace-scope-operator/IBM.ibm-namespace-scope-operator.master.yaml
@@ -17,7 +17,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -40,7 +40,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -63,7 +63,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -86,7 +86,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -111,7 +111,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -133,7 +133,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -155,7 +155,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -177,7 +177,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-namespace-scope-operator/IBM.ibm-namespace-scope-operator.release-1.0.yaml
+++ b/prow/cluster/jobs/IBM/ibm-namespace-scope-operator/IBM.ibm-namespace-scope-operator.release-1.0.yaml
@@ -13,7 +13,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -32,7 +32,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -51,7 +51,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -70,7 +70,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -91,7 +91,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -109,7 +109,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -127,7 +127,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -145,7 +145,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-namespace-scope-operator/IBM.ibm-namespace-scope-operator.release-1.1.yaml
+++ b/prow/cluster/jobs/IBM/ibm-namespace-scope-operator/IBM.ibm-namespace-scope-operator.release-1.1.yaml
@@ -13,7 +13,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -32,7 +32,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -51,7 +51,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -70,7 +70,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -91,7 +91,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -109,7 +109,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -127,7 +127,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -145,7 +145,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-platform-api-operator/IBM.ibm-platform-api-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-platform-api-operator/IBM.ibm-platform-api-operator.master.yaml
@@ -40,7 +40,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -63,7 +63,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -86,7 +86,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -111,7 +111,7 @@ presubmits:
         - entrypoint
         - make
         - build-operator-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -136,7 +136,7 @@ presubmits:
         - entrypoint
         - make
         - build-operator-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -161,7 +161,7 @@ presubmits:
         - entrypoint
         - make
         - build-operator-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -186,7 +186,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -208,7 +208,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -230,7 +230,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -252,7 +252,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-secretshare-operator/IBM.ibm-secretshare-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-secretshare-operator/IBM.ibm-secretshare-operator.master.yaml
@@ -17,7 +17,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -40,7 +40,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -63,7 +63,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -86,7 +86,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -109,7 +109,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -132,7 +132,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -155,7 +155,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -180,7 +180,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -202,7 +202,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -224,7 +224,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -246,7 +246,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-secretshare-operator/IBM.ibm-secretshare-operator.release-1.3.yaml
+++ b/prow/cluster/jobs/IBM/ibm-secretshare-operator/IBM.ibm-secretshare-operator.release-1.3.yaml
@@ -13,7 +13,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -32,7 +32,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -51,7 +51,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -70,7 +70,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -89,7 +89,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -108,7 +108,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -127,7 +127,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -145,7 +145,7 @@ postsubmits:
       - command:
         - make
         - coverage
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         env:
         - name: CODECOV_TOKEN
@@ -169,7 +169,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -187,7 +187,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -205,7 +205,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -223,7 +223,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/ibm-secretshare-operator/IBM.ibm-secretshare-operator.release-1.4.yaml
+++ b/prow/cluster/jobs/IBM/ibm-secretshare-operator/IBM.ibm-secretshare-operator.release-1.4.yaml
@@ -13,7 +13,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -32,7 +32,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -51,7 +51,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -70,7 +70,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -89,7 +89,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -108,7 +108,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -127,7 +127,7 @@ presubmits:
         - entrypoint
         - make
         - build
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -145,7 +145,7 @@ postsubmits:
       - command:
         - make
         - coverage
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         env:
         - name: CODECOV_TOKEN
@@ -169,7 +169,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -187,7 +187,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -205,7 +205,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -223,7 +223,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/operand-deployment-lifecycle-manager/IBM.operand-deployment-lifecycle-manager.master.yaml
+++ b/prow/cluster/jobs/IBM/operand-deployment-lifecycle-manager/IBM.operand-deployment-lifecycle-manager.master.yaml
@@ -18,7 +18,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -42,7 +42,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -68,7 +68,7 @@ presubmits:
         - entrypoint
         - make
         - e2e-test-kind
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -94,7 +94,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -117,7 +117,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -140,7 +140,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -163,7 +163,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/operand-deployment-lifecycle-manager/IBM.operand-deployment-lifecycle-manager.release-1.4.yaml
+++ b/prow/cluster/jobs/IBM/operand-deployment-lifecycle-manager/IBM.operand-deployment-lifecycle-manager.release-1.4.yaml
@@ -13,7 +13,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -32,7 +32,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -53,7 +53,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -71,7 +71,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -89,7 +89,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -107,7 +107,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true

--- a/prow/cluster/jobs/IBM/operand-deployment-lifecycle-manager/IBM.operand-deployment-lifecycle-manager.release-1.5.yaml
+++ b/prow/cluster/jobs/IBM/operand-deployment-lifecycle-manager/IBM.operand-deployment-lifecycle-manager.release-1.5.yaml
@@ -13,7 +13,7 @@ presubmits:
       - command:
         - make
         - check
-        image: quay.io/multicloudlab/check-tool:v20221107-59a355d03
+        image: quay.io/cicdtest/check-tool:v20230104-58a80daad
         name: ""
         securityContext:
           privileged: true
@@ -32,7 +32,7 @@ presubmits:
         - entrypoint
         - make
         - test
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -53,7 +53,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -71,7 +71,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -89,7 +89,7 @@ postsubmits:
         - entrypoint
         - make
         - build-push-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true
@@ -107,7 +107,7 @@ postsubmits:
         - entrypoint
         - make
         - multiarch-image
-        image: quay.io/multicloudlab/build-tool:v20221107-3b1566bf9
+        image: quay.io/cicdtest/build-tool:v20230104-558747cdc
         name: ""
         securityContext:
           privileged: true


### PR DESCRIPTION
Signed-off-by: Xinchun Liu <xcliu@ca.ibm.com>

**What this PR does / why we need it**:

updated tools images to golang 1.18.9 for operators to meet security requirements

**Specify your PR reviewers**:
<!-- Add or remove reviewers as your request -->
/cc @ashank07 @pgodowski 

