### PR TITLE
Update ibm-user-management-operator build branch

### DIFF
--- a/prow/cluster/jobs/IBM/ibm-user-management-operator/IBM.ibm-user-management-operator.master.yaml
+++ b/prow/cluster/jobs/IBM/ibm-user-management-operator/IBM.ibm-user-management-operator.master.yaml
@@ -4,7 +4,7 @@ presubmits:
     cluster: default
     always_run: true
     branches:
-    - ^main$
+    - ^master$
     - ^release-future$
     decorate: true
     path_alias: github.com/IBM/ibm-user-management-operator 
@@ -23,7 +23,7 @@ presubmits:
     cluster: default
     always_run: true
     branches:
-    - ^main$
+    - ^master$
     - ^release-future$
     decorate: true
     path_alias: github.com/IBM/ibm-user-management-operator
@@ -43,7 +43,7 @@ presubmits:
     cluster: ppc64le
     always_run: true
     branches:
-    - ^main$
+    - ^master$
     - ^release-future$
     decorate: true
     path_alias: github.com/IBM/ibm-user-management-operator
@@ -63,7 +63,7 @@ presubmits:
     cluster: s390x
     always_run: true
     branches:
-    - ^main$
+    - ^master$
     - ^release-future$
     decorate: true
     path_alias: github.com/IBM/ibm-user-management-operator
@@ -84,7 +84,7 @@ postsubmits:
   - name: multiarch-image-ibm-user-management-operator-postsubmit
     cluster: default
     branches:
-    - ^main$
+    - ^master$
     - ^release-future$
     decorate: true
     labels:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the branch used to run the ibm-user-management-operator builds

