### PR TITLE
Fix GOSUMDB value

### DIFF
--- a/prow/docker/build-tool/Dockerfile
+++ b/prow/docker/build-tool/Dockerfile
@@ -168,7 +168,7 @@ ENV LANG=C.UTF-8
 # Go support
 ENV GO111MODULE=on
 ENV GOPROXY=https://proxy.golang.org
-ENV GOSUMDB=https://sum.golang.org
+ENV GOSUMDB=sum.golang.org
 ENV GOROOT=/usr/local/go
 ENV GOPATH=${HOME}/go
 ENV GOBIN=${HOME}/gobin

--- a/prow/docker/check-tool/Dockerfile
+++ b/prow/docker/check-tool/Dockerfile
@@ -228,7 +228,7 @@ ENV LANG=C.UTF-8
 # Go support
 ENV GO111MODULE=on
 ENV GOPROXY=https://proxy.golang.org
-ENV GOSUMDB=https://sum.golang.org
+ENV GOSUMDB=sum.golang.org
 ENV GOROOT=/usr/local/go
 ENV GOPATH=${HOME}/go
 ENV GOBIN=${HOME}/gobin


### PR DESCRIPTION
Previously, GOSUMDB was set to "https://sum.golang.org". The "https://" breaks verification, so changing this to sum.golang.org clears up "malformed verifier id" errors.
